### PR TITLE
Set default working directory to current git project root

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,27 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}"
+            }
+        },
+        {
+            "name": "Python: Current File (External Terminal)",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "externalTerminal",
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}"
+            }
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,17 @@
+{
+    "terminal.integrated.cwd": "${workspaceFolder}",
+    "python.terminal.activateEnvironment": true,
+    "python.defaultInterpreterPath": "python3",
+    "files.exclude": {
+        "**/.git": true,
+        "**/.DS_Store": true,
+        "**/__pycache__": true,
+        "**/*.pyc": true
+    },
+    "search.exclude": {
+        "**/.git": true,
+        "**/node_modules": true,
+        "**/bower_components": true,
+        "**/*.code-search": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Python File",
+            "type": "shell",
+            "command": "python",
+            "args": ["${file}"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "Run Current Directory",
+            "type": "shell",
+            "command": "python",
+            "args": ["-m", "pytest"],
+            "group": "test",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        }
+    ]
+}

--- a/VSCode_Workspace_Setup.md
+++ b/VSCode_Workspace_Setup.md
@@ -1,0 +1,62 @@
+# VSCode 工作区配置说明
+
+## 问题描述
+在VSCode中通过SSH远程连接工作区时，当有多个git项目时，默认工作目录可能不是当前git项目的根目录，导致相对路径导入和文件路径出现问题。
+
+## 解决方案
+
+### 1. 使用工作区文件（推荐）
+- 双击 `workspace.code-workspace` 文件打开工作区
+- 或者通过 `File > Open Workspace from File...` 选择该文件
+
+### 2. 配置文件说明
+
+#### `.vscode/settings.json`
+- `terminal.integrated.cwd`: 设置终端默认工作目录为当前工作区文件夹
+- `python.terminal.activateEnvironment`: 自动激活Python虚拟环境
+- `python.defaultInterpreterPath`: 设置默认Python解释器
+
+#### `.vscode/launch.json`
+- 配置调试器启动时使用正确的工作目录
+- 设置 `PYTHONPATH` 环境变量为工作区根目录
+
+#### `.vscode/tasks.json`
+- 配置任务运行时使用正确的工作目录
+- 提供常用的Python运行和测试任务
+
+### 3. 使用方法
+
+#### 运行Python文件
+1. 打开要运行的Python文件
+2. 按 `F5` 或使用调试面板运行
+3. 或者按 `Ctrl+Shift+P` 运行任务
+
+#### 在终端中运行
+1. 打开集成终端 (`Ctrl+`` `)
+2. 终端会自动切换到当前工作区目录
+3. 直接运行Python命令
+
+#### 切换项目
+1. 关闭当前工作区
+2. 打开新的git项目目录
+3. 使用 `File > Open Folder...` 打开新项目
+4. 或者复制这些配置文件到新项目中
+
+### 4. 环境变量设置
+确保 `PYTHONPATH` 包含当前项目根目录，这样Python就能正确找到模块：
+```bash
+export PYTHONPATH="${PYTHONPATH}:$(pwd)"
+```
+
+### 5. 验证配置
+运行以下命令验证工作目录是否正确：
+```python
+import os
+print("当前工作目录:", os.getcwd())
+print("Python路径:", os.environ.get('PYTHONPATH', ''))
+```
+
+## 注意事项
+- 每个git项目都需要这些配置文件
+- 可以通过脚本自动复制这些配置文件到新项目中
+- 如果使用虚拟环境，确保在settings.json中指定正确的Python解释器路径

--- a/setup_vscode_config.sh
+++ b/setup_vscode_config.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+# VSCode 工作区配置自动设置脚本
+# 使用方法: ./setup_vscode_config.sh [项目路径]
+
+PROJECT_PATH=${1:-.}
+
+echo "正在为项目 $PROJECT_PATH 设置VSCode配置..."
+
+# 创建.vscode目录
+mkdir -p "$PROJECT_PATH/.vscode"
+
+# 创建settings.json
+cat > "$PROJECT_PATH/.vscode/settings.json" << 'EOF'
+{
+    "terminal.integrated.cwd": "${workspaceFolder}",
+    "python.terminal.activateEnvironment": true,
+    "python.defaultInterpreterPath": "python3",
+    "files.exclude": {
+        "**/.git": true,
+        "**/.DS_Store": true,
+        "**/__pycache__": true,
+        "**/*.pyc": true
+    },
+    "search.exclude": {
+        "**/.git": true,
+        "**/node_modules": true,
+        "**/bower_components": true,
+        "**/*.code-search": true
+    }
+}
+EOF
+
+# 创建launch.json
+cat > "$PROJECT_PATH/.vscode/launch.json" << 'EOF'
+{
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python: Current File",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "integratedTerminal",
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}"
+            }
+        },
+        {
+            "name": "Python: Current File (External Terminal)",
+            "type": "python",
+            "request": "launch",
+            "program": "${file}",
+            "console": "externalTerminal",
+            "cwd": "${workspaceFolder}",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}"
+            }
+        }
+    ]
+}
+EOF
+
+# 创建tasks.json
+cat > "$PROJECT_PATH/.vscode/tasks.json" << 'EOF'
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Run Python File",
+            "type": "shell",
+            "command": "python",
+            "args": ["${file}"],
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            },
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        },
+        {
+            "label": "Run Current Directory",
+            "type": "shell",
+            "command": "python",
+            "args": ["-m", "pytest"],
+            "group": "test",
+            "presentation": {
+                "echo": true,
+                "reveal": "always",
+                "focus": false,
+                "panel": "shared"
+            },
+            "options": {
+                "cwd": "${workspaceFolder}"
+            }
+        }
+    ]
+}
+EOF
+
+# 创建工作区文件
+PROJECT_NAME=$(basename "$(realpath "$PROJECT_PATH")")
+cat > "$PROJECT_PATH/${PROJECT_NAME}.code-workspace" << EOF
+{
+    "folders": [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        "terminal.integrated.cwd": "\${workspaceFolder}",
+        "python.terminal.activateEnvironment": true,
+        "python.defaultInterpreterPath": "python3",
+        "files.exclude": {
+            "**/.git": true,
+            "**/.DS_Store": true,
+            "**/__pycache__": true,
+            "**/*.pyc": true
+        },
+        "search.exclude": {
+            "**/.git": true,
+            "**/node_modules": true,
+            "**/bower_components": true,
+            "**/*.code-search": true
+        }
+    },
+    "extensions": {
+        "recommendations": [
+            "ms-python.python",
+            "ms-python.vscode-pylance",
+            "ms-vscode.vscode-json"
+        ]
+    }
+}
+EOF
+
+echo "✅ VSCode配置设置完成！"
+echo "📁 配置文件位置: $PROJECT_PATH/.vscode/"
+echo "🔧 工作区文件: $PROJECT_PATH/${PROJECT_NAME}.code-workspace"
+echo ""
+echo "💡 使用方法:"
+echo "1. 双击 ${PROJECT_NAME}.code-workspace 文件打开工作区"
+echo "2. 或者使用 File > Open Workspace from File... 选择该文件"
+echo "3. 现在运行代码时，工作目录将自动设置为当前项目根目录"

--- a/test_workspace_config.py
+++ b/test_workspace_config.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+测试VSCode工作区配置是否正确
+"""
+
+import os
+import sys
+
+def test_workspace_config():
+    """测试工作区配置"""
+    print("=" * 50)
+    print("VSCode 工作区配置测试")
+    print("=" * 50)
+    
+    # 获取当前工作目录
+    current_dir = os.getcwd()
+    print(f"当前工作目录: {current_dir}")
+    
+    # 获取Python路径
+    python_path = os.environ.get('PYTHONPATH', '')
+    print(f"PYTHONPATH: {python_path}")
+    
+    # 获取系统路径
+    print(f"Python系统路径:")
+    for i, path in enumerate(sys.path):
+        print(f"  {i}: {path}")
+    
+    # 检查是否在git仓库中
+    git_dir = os.path.join(current_dir, '.git')
+    if os.path.exists(git_dir):
+        print(f"✅ 当前目录是git仓库")
+    else:
+        print(f"⚠️  当前目录不是git仓库")
+    
+    # 检查是否有.vscode目录
+    vscode_dir = os.path.join(current_dir, '.vscode')
+    if os.path.exists(vscode_dir):
+        print(f"✅ 找到.vscode配置目录")
+        
+        # 检查配置文件
+        config_files = ['settings.json', 'launch.json', 'tasks.json']
+        for config_file in config_files:
+            config_path = os.path.join(vscode_dir, config_file)
+            if os.path.exists(config_path):
+                print(f"  ✅ {config_file}")
+            else:
+                print(f"  ❌ {config_file}")
+    else:
+        print(f"❌ 未找到.vscode配置目录")
+    
+    # 检查工作区文件
+    workspace_files = [f for f in os.listdir(current_dir) if f.endswith('.code-workspace')]
+    if workspace_files:
+        print(f"✅ 找到工作区文件: {workspace_files}")
+    else:
+        print(f"❌ 未找到工作区文件")
+    
+    print("\n" + "=" * 50)
+    print("测试完成")
+    print("=" * 50)
+
+if __name__ == "__main__":
+    test_workspace_config()

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -1,0 +1,31 @@
+{
+    "folders": [
+        {
+            "path": "."
+        }
+    ],
+    "settings": {
+        "terminal.integrated.cwd": "${workspaceFolder}",
+        "python.terminal.activateEnvironment": true,
+        "python.defaultInterpreterPath": "python3",
+        "files.exclude": {
+            "**/.git": true,
+            "**/.DS_Store": true,
+            "**/__pycache__": true,
+            "**/*.pyc": true
+        },
+        "search.exclude": {
+            "**/.git": true,
+            "**/node_modules": true,
+            "**/bower_components": true,
+            "**/*.code-search": true
+        }
+    },
+    "extensions": {
+        "recommendations": [
+            "ms-python.python",
+            "ms-python.vscode-pylance",
+            "ms-vscode.vscode-json"
+        ]
+    }
+}


### PR DESCRIPTION
Configure VSCode to set the working directory to the current Git project root in remote SSH workspaces, resolving path and import issues.

---
<a href="https://cursor.com/background-agent?bcId=bc-445eb380-bb14-44d3-a6e0-d9997dc355d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-445eb380-bb14-44d3-a6e0-d9997dc355d3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>